### PR TITLE
specify files to pack to avoid oclif warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
     "nyc": "8.4.0",
     "standard": "8.5.0",
     "std-mocks": "1.0.1"
-  }
+  },
+  "files": [
+    "/index.js",
+    "/commands"
+  ]
 }


### PR DESCRIPTION
this attribute is now required in plugins otherwise a warning is displayed (though notably, the plugins still work fine with the warning)

See my blog post for the reason why this is now required: https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d

for other plugins, if you run `npm pack; tar -xvzf *.tgz; rm -rf package *.tgz` that will print the files it's currently packing