### PR TITLE
Send a meaningful error when no release were found

### DIFF
--- a/commands/retry.js
+++ b/commands/retry.js
@@ -13,6 +13,10 @@ function * run (context, heroku) {
   }
   let release = yield getLatestRelease()
 
+  if (!release) {
+    return cli.error('No release found for this app')
+  }
+
   let retry = yield cli.action(`Retrying ${cli.color.green('v' + release.version)} on ${cli.color.app(context.app)}`, {success: false}, co(function * () {
     let r = yield heroku.post(`/apps/${context.app}/releases`, {
       body: {

--- a/test/commands/retry.js
+++ b/test/commands/retry.js
@@ -10,6 +10,16 @@ const stdMocks = require('std-mocks')
 describe('releases:retry', function () {
   beforeEach(() => cli.mockConsole())
 
+  it('errors when there are no releases yet', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/releases')
+      .reply(200, [])
+    return cmd.run({app: 'myapp'})
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.contain('No release found for this app'))
+      .then(() => api.done())
+  })
+
   it('retries the release', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')


### PR DESCRIPTION
We can't retry if the app has no releases.

Closes #6 