### PR TITLE
Add more context to retried release description

### DIFF
--- a/commands/retry.js
+++ b/commands/retry.js
@@ -21,7 +21,7 @@ function * run (context, heroku) {
     let r = yield heroku.post(`/apps/${context.app}/releases`, {
       body: {
         slug: release.slug.id,
-        description: `Retrying v${release.version}`
+        description: `Retry of v${release.version}: ${release.description}`
       }
     })
 

--- a/test/commands/retry.js
+++ b/test/commands/retry.js
@@ -23,8 +23,8 @@ describe('releases:retry', function () {
   it('retries the release', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{ 'slug': { id: 'slug_uuid' }, version: 40 }])
-      .post('/apps/myapp/releases', { slug: 'slug_uuid', description: 'Retrying v40' })
+      .reply(200, [{ 'slug': { id: 'slug_uuid' }, version: 40, description: 'A release' }])
+      .post('/apps/myapp/releases', { slug: 'slug_uuid', description: 'Retry of v40: A release' })
       .reply(200, {})
     return cmd.run({app: 'myapp'})
       .then(() => api.done())
@@ -37,8 +37,8 @@ describe('releases:retry', function () {
       .reply(200, 'Release Output Content')
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{ 'slug': { id: 'slug_uuid' }, version: 40 }])
-      .post('/apps/myapp/releases', { slug: 'slug_uuid', description: 'Retrying v40' })
+      .reply(200, [{ 'slug': { id: 'slug_uuid' }, version: 40, description: 'A release' }])
+      .post('/apps/myapp/releases', { slug: 'slug_uuid', description: 'Retry of v40: A release' })
       .reply(200, {output_stream_url: 'https://busl.test/streams/release.log'})
 
     return cmd.run({app: 'myapp'})
@@ -56,8 +56,8 @@ describe('releases:retry', function () {
       .reply(404, '')
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{ 'slug': { id: 'slug_uuid' }, version: 40 }])
-      .post('/apps/myapp/releases', { slug: 'slug_uuid', description: 'Retrying v40' })
+      .reply(200, [{ 'slug': { id: 'slug_uuid' }, version: 40, description: 'A release' }])
+      .post('/apps/myapp/releases', { slug: 'slug_uuid', description: 'Retry of v40: A release' })
       .reply(200, {version: 1, output_stream_url: 'https://busl.test/streams/release.log'})
 
     return cmd.run({app: 'myapp'})


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-releases-retry/issues/9

The current "Retrying" message in the description of a retried release might be misleading, as one could understand that the release is still running, and this PR aims to help with that.

