### PR TITLE
Document the fact that the plugin doesn't support container apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ Run the following command:
 Retry the latest release:
 
 > heroku releases:retry --app happy-samurai-42
+
+## Usage with container apps
+
+The plugin doesn't support container apps. You will get the following error:
+
+```
+Cannot read property 'id' of null
+```
+
+You need to push a new image instead of using this plugin.


### PR DESCRIPTION
Currently the plugin throws an exception on an attempt to use it with a container app:

```
Cannot read property 'id' of null
```

My colleagues and other people (#8, #6 at least) experienced this issue. One of my colleagues has done some digging and it looks like the plugin fails because Heroku API returns `null` in the `slug` field for container apps. We contacted the Heroku support team and it turns out that it's expected behaviour.

From the response we received from Heroku about this issue, It doesn't look like there are plans in place to make this plugin work with container apps. Would be great to document this:

> I'm sorry this isn't possible as our API will ignore release updates of the same docker image. Unfortunately, you need to push a new image.